### PR TITLE
use es5 target for IE11 support

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
 		"rootDir": "src",
 		"outDir": "dist",
 		"sourceMap": true,
-		"target": "es2015",
+		"target": "es5",
 		"emitDecoratorMetadata": true,
 		"experimentalDecorators": true
 	},


### PR DESCRIPTION
Thank you for the helpful library. A must have for Angular projects.

I have ran into issues with IE11 listed below:
https://github.com/angular/angular-cli/issues/9508
https://github.com/angular/angular-cli/issues/7303

It is fixed with a `target` change in `package.json` for this library.
I have tried it on IE11 and Chrome myself. Please review if it causes unintended consequences for other users.

If all goes well, it would be awesome to see this merged and released in the next version. Thank you very much!